### PR TITLE
refactor: re-export modules and add node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepare": "npm run build"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
     "hono": "^4.8.12"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.2"
   },
   "dependencies": {
     "zod": "^3.24.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-export { BaseModel, BeforeCreate, AfterCreate, BeforeUpdate, AfterUpdate, BeforeDelete, AfterDelete } from './BaseModel';
-export { BaseController } from './BaseController';
-export type { ControllerOptions } from './BaseController';
-export { QueryService } from './QueryService';
-export { requireAuth } from './requireAuth';
-export type { AuthCheckFn } from './requireAuth';
+export * from './BaseModel';
+export * from './BaseController';
+export * from './QueryService';
+export * from './requireAuth';


### PR DESCRIPTION
## Summary
- ensure all modules are re-exported from the package entry point
- include Node type definitions for successful builds
- compile the library automatically when installed via `prepare` script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a752397fd4832185ead572291ceee0