### PR TITLE
Add todo example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ These hooks run automatically around the respective operations.
 
 ## Example
 
-A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos, and includes a `docker-compose.yml` for spinning up a local DynamoDB instance.
+A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos, and includes a `docker-compose.yml` for spinning up a local DynamoDB instance. See its [README](examples/todo/README.md) for setup instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ These hooks run automatically around the respective operations.
 
 ## Example
 
-A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos.
+A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos, and includes a `docker-compose.yml` for spinning up a local DynamoDB instance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ class UserModel extends BaseModel<typeof UserSchema> {
 
 These hooks run automatically around the respective operations.
 
+## Example
+
+A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos.
+
 ---
 
 dmvc aims to stay minimal. See the source for additional helpers like `requireAuth` and `QueryService`.

--- a/examples/todo/.env
+++ b/examples/todo/.env
@@ -1,0 +1,2 @@
+DYNAMODB_TABLE_NAME=todos
+DYNAMODB_ENDPOINT=http://localhost:8000

--- a/examples/todo/.env.example
+++ b/examples/todo/.env.example
@@ -1,0 +1,2 @@
+DYNAMODB_TABLE_NAME=todos
+DYNAMODB_ENDPOINT=http://localhost:8000

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -37,3 +37,36 @@ Shut down the local database with:
 ```bash
 npm run db:down
 ```
+
+## Table configuration
+
+When defining the DynamoDB table in an SST app, include the additional indexes expected by this example:
+
+```ts
+const table = new sst.aws.Dynamo("SomeTableName", {
+  fields: {
+    pk: "string",
+    sk: "string",
+    gsi1pk: "string",
+    gsi1sk: "string",
+    gsi2pk: "string",
+    gsi2sk: "string",
+  },
+  primaryIndex: {
+    hashKey: "pk",
+    rangeKey: "sk",
+  },
+  globalIndexes: {
+    "gsi1pk-gsi1sk-index": {
+      hashKey: "gsi1pk",
+      rangeKey: "gsi1sk",
+    },
+    "gsi2pk-gsi2sk-index": {
+      hashKey: "gsi2pk",
+      rangeKey: "gsi2sk",
+    },
+  },
+});
+```
+
+These fields and indexes mirror those referenced in `index.ts` and allow for more advanced query patterns.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -1,0 +1,39 @@
+# Todo Example
+
+This example shows a tiny todo application built with [dmvc](../../README.md), [Hono](https://hono.dev) and DynamoDB.
+
+## Prerequisites
+
+- Node.js 18+
+- [Docker](https://www.docker.com/) for the local DynamoDB instance
+
+## Setup
+
+```bash
+# install dependencies
+npm install
+cd examples/todo
+npm install
+
+# start DynamoDB
+npm run db:up
+```
+
+An `.env` file is provided that configures the table name and points the AWS SDK at the local DynamoDB endpoint exposed by `docker-compose`.
+
+## CRUD helpers
+
+With DynamoDB running you can exercise the model directly from the command line:
+
+```bash
+npm run create
+npm run read <id>
+npm run update <id>
+npm run destroy <id>
+```
+
+Shut down the local database with:
+
+```bash
+npm run db:down
+```

--- a/examples/todo/docker-compose.yml
+++ b/examples/todo/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  dynamodb:
+    image: amazon/dynamodb-local:latest
+    ports:
+      - "8000:8000"
+    command: -jar DynamoDBLocal.jar -inMemory -sharedDb

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 const TodoSchema = z.object({
   id: z.string(),
   title: z.string(),
-  completed: z.boolean().optional(),
+  completed: z.boolean().default(false),
 });
 
 // model backed by ElectroDB
@@ -25,10 +25,24 @@ class TodoModel extends BaseModel<typeof TodoSchema> {
         attributes: {
           id: { type: 'string', required: true },
           title: { type: 'string', required: true },
-          completed: { type: 'boolean' },
+          completed: { type: 'boolean', default: false },
+          type: { type: 'string', required: true, default: 'todo' },
         },
         indexes: {
-          primary: { pk: { field: 'pk', composite: ['id'] } },
+          primary: {
+            pk: { field: 'pk', composite: ['type'] },
+            sk: { field: 'sk', composite: ['id'] },
+          },
+          byTitle: {
+            index: 'gsi1pk-gsi1sk-index',
+            pk: { field: 'gsi1pk', composite: ['title'] },
+            sk: { field: 'gsi1sk', composite: ['id'] },
+          },
+          byCompleted: {
+            index: 'gsi2pk-gsi2sk-index',
+            pk: { field: 'gsi2pk', composite: ['completed'] },
+            sk: { field: 'gsi2sk', composite: ['id'] },
+          },
         },
       },
       { client, table }

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { Hono } from 'hono';
 import { BaseController, BaseModel } from 'dmvc';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -36,7 +36,13 @@ class TodoModel extends BaseModel<typeof TodoSchema> {
 }
 
 // initialize DynamoDB connection once
-const raw = new DynamoDBClient({ region: 'us-east-1' });
+const raw = new DynamoDBClient({
+  region: 'us-east-1',
+  endpoint: process.env.DYNAMODB_ENDPOINT,
+  credentials: process.env.DYNAMODB_ENDPOINT
+    ? { accessKeyId: 'local', secretAccessKey: 'local' }
+    : undefined,
+});
 const client = DynamoDBDocumentClient.from(raw);
 BaseModel.configure({ client, table: process.env.DYNAMODB_TABLE_NAME! });
 

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down",
     "create": "tsx scripts.ts create",
     "read": "tsx scripts.ts read",
     "update": "tsx scripts.ts update",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "todo-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "create": "tsx scripts.ts create",
+    "read": "tsx scripts.ts read",
+    "update": "tsx scripts.ts update",
+    "destroy": "tsx scripts.ts destroy"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.1"
+  }
+}

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -11,6 +11,7 @@
     "destroy": "tsx scripts.ts destroy"
   },
   "devDependencies": {
+    "dotenv": "^16.4.5",
     "tsx": "^4.7.1"
   }
 }

--- a/examples/todo/scripts.ts
+++ b/examples/todo/scripts.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto';
+import { TodoModel } from './index';
+
+async function main() {
+  const [, , command, id] = process.argv;
+  try {
+    switch (command) {
+      case 'create': {
+        const todo = await TodoModel.create({ id: randomUUID(), title: 'demo todo' });
+        console.log(todo);
+        break;
+      }
+      case 'read': {
+        if (!id) throw new Error('ID required');
+        const todo = await TodoModel.get({ id });
+        console.log(todo);
+        break;
+      }
+      case 'update': {
+        if (!id) throw new Error('ID required');
+        const todo = await TodoModel.update({ id, completed: true });
+        console.log(todo);
+        break;
+      }
+      case 'destroy': {
+        if (!id) throw new Error('ID required');
+        const result = await TodoModel.delete({ id });
+        console.log(result);
+        break;
+      }
+      default:
+        console.log('Usage: tsx scripts.ts <create|read|update|destroy> [id]');
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+main();

--- a/examples/todo/scripts.ts
+++ b/examples/todo/scripts.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { randomUUID } from 'crypto';
 import { TodoModel } from './index';
 


### PR DESCRIPTION
## Summary
- add minimal todo example using dmvc, Hono, DynamoDB and Zod
- document example location in README
- add package.json and CLI scripts to create, read, update, and destroy todos

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7768a13748321a18cc6d14815765d