### PR TITLE
feat(example): auto create todo table

### DIFF
--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -21,6 +21,8 @@ npm run db:up
 
 An `.env` file is provided that configures the table name and points the AWS SDK at the local DynamoDB endpoint exposed by `docker-compose`.
 
+The helper scripts will automatically create the required table and indexes if they do not already exist.
+
 ## CRUD helpers
 
 With DynamoDB running you can exercise the model directly from the command line:

--- a/examples/todo/scripts.ts
+++ b/examples/todo/scripts.ts
@@ -1,10 +1,75 @@
 import 'dotenv/config';
 import { randomUUID } from 'crypto';
+import {
+  DynamoDBClient,
+  CreateTableCommand,
+  DescribeTableCommand,
+} from '@aws-sdk/client-dynamodb';
 import { TodoModel } from './index';
+
+async function ensureTable() {
+  if (!process.env.DYNAMODB_TABLE_NAME) return;
+
+  const client = new DynamoDBClient({
+    region: 'us-east-1',
+    endpoint: process.env.DYNAMODB_ENDPOINT,
+    credentials: process.env.DYNAMODB_ENDPOINT
+      ? { accessKeyId: 'local', secretAccessKey: 'local' }
+      : undefined,
+  });
+
+  try {
+    await client.send(
+      new DescribeTableCommand({
+        TableName: process.env.DYNAMODB_TABLE_NAME,
+      }),
+    );
+  } catch (err: any) {
+    if (err.name !== 'ResourceNotFoundException') throw err;
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: process.env.DYNAMODB_TABLE_NAME,
+        AttributeDefinitions: [
+          { AttributeName: 'pk', AttributeType: 'S' },
+          { AttributeName: 'sk', AttributeType: 'S' },
+          { AttributeName: 'gsi1pk', AttributeType: 'S' },
+          { AttributeName: 'gsi1sk', AttributeType: 'S' },
+          { AttributeName: 'gsi2pk', AttributeType: 'S' },
+          { AttributeName: 'gsi2sk', AttributeType: 'S' },
+        ],
+        KeySchema: [
+          { AttributeName: 'pk', KeyType: 'HASH' },
+          { AttributeName: 'sk', KeyType: 'RANGE' },
+        ],
+        BillingMode: 'PAY_PER_REQUEST',
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: 'gsi1pk-gsi1sk-index',
+            KeySchema: [
+              { AttributeName: 'gsi1pk', KeyType: 'HASH' },
+              { AttributeName: 'gsi1sk', KeyType: 'RANGE' },
+            ],
+            Projection: { ProjectionType: 'ALL' },
+          },
+          {
+            IndexName: 'gsi2pk-gsi2sk-index',
+            KeySchema: [
+              { AttributeName: 'gsi2pk', KeyType: 'HASH' },
+              { AttributeName: 'gsi2sk', KeyType: 'RANGE' },
+            ],
+            Projection: { ProjectionType: 'ALL' },
+          },
+        ],
+      }),
+    );
+  }
+}
 
 async function main() {
   const [, , command, id] = process.argv;
   try {
+    await ensureTable();
     switch (command) {
       case 'create': {
         const todo = await TodoModel.create({ id: randomUUID(), title: 'demo todo' });


### PR DESCRIPTION
## Summary
- ensure Todo example CLI creates DynamoDB table and GSIs on demand
- document automatic table creation in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a79efac540832180fafc322c4a45b0