### PR TITLE
feat(example): add paginated todo listing

### DIFF
--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -32,7 +32,11 @@ npm run create
 npm run read <id>
 npm run update <id>
 npm run destroy <id>
+npm run list [cursor] [limit]
 ```
+
+The list command returns a page of todos and prints a `cursor` value that
+can be supplied on subsequent runs to fetch the next page.
 
 Shut down the local database with:
 

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -8,7 +8,8 @@
     "create": "tsx scripts.ts create",
     "read": "tsx scripts.ts read",
     "update": "tsx scripts.ts update",
-    "destroy": "tsx scripts.ts destroy"
+    "destroy": "tsx scripts.ts destroy",
+    "list": "tsx scripts.ts list"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/examples/todo/scripts.ts
+++ b/examples/todo/scripts.ts
@@ -67,7 +67,7 @@ async function ensureTable() {
 }
 
 async function main() {
-  const [, , command, id] = process.argv;
+  const [, , command, arg1, arg2] = process.argv;
   try {
     await ensureTable();
     switch (command) {
@@ -77,25 +77,34 @@ async function main() {
         break;
       }
       case 'read': {
-        if (!id) throw new Error('ID required');
-        const todo = await TodoModel.get({ id });
+        if (!arg1) throw new Error('ID required');
+        const todo = await TodoModel.get({ id: arg1 });
         console.log(todo);
         break;
       }
       case 'update': {
-        if (!id) throw new Error('ID required');
-        const todo = await TodoModel.update({ id, completed: true });
+        if (!arg1) throw new Error('ID required');
+        const todo = await TodoModel.update({ id: arg1, completed: true });
         console.log(todo);
         break;
       }
       case 'destroy': {
-        if (!id) throw new Error('ID required');
-        const result = await TodoModel.delete({ id });
+        if (!arg1) throw new Error('ID required');
+        const result = await TodoModel.delete({ id: arg1 });
+        console.log(result);
+        break;
+      }
+      case 'list': {
+        const cursor = arg1;
+        const limit = arg2 ? parseInt(arg2, 10) : undefined;
+        const result = await TodoModel.list(cursor, limit);
         console.log(result);
         break;
       }
       default:
-        console.log('Usage: tsx scripts.ts <create|read|update|destroy> [id]');
+        console.log(
+          'Usage: tsx scripts.ts <create|read|update|destroy|list> [id|cursor] [limit]'
+        );
     }
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- add list script for paging through todos
- document list usage in todo example

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a266bb848321bad9dc07fffddd89