### PR TITLE
fix: handle missing lockfile in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install deps
-        run: npm ci
+        run: npm ci || npm install --no-package-lock
 
       # optional: run tests / build
       - name: Test


### PR DESCRIPTION
## Summary
- allow release workflow to install dependencies without a lockfile by falling back to `npm install`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa182e0cf48321ac1702135b383664