### PR TITLE
feat: add model and controller generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   "bugs": {
     "url": "https://github.com/bishopandco/dmvc/issues"
   },
-  "homepage": "https://github.com/bishopandco/dmvc#readme"
+  "homepage": "https://github.com/bishopandco/dmvc#readme",
+  "bin": {
+    "dmvc": "dist/generator.js"
+  }
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+
+function toPascalCase(str: string): string {
+  return str
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+(\w)/g, (_, c) => c.toUpperCase())
+    .replace(/^(\w)/, (_, c) => c.toUpperCase());
+}
+
+function ensureDir(dir: string) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function generateModel(name: string, baseDir: string = process.cwd()) {
+  const className = toPascalCase(name);
+  const dir = path.join(baseDir, 'src', 'models');
+  const filePath = path.join(dir, `${className}.ts`);
+  ensureDir(dir);
+  if (existsSync(filePath)) {
+    throw new Error(`Model already exists: ${filePath}`);
+  }
+  const content = `import { BaseModel } from "@bishop-and-co/dmvc";
+import { Entity } from "electrodb";
+import { z } from "zod";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+
+const ${className}Schema = z.object({
+  id: z.string(),
+  // define additional attributes here
+});
+
+const ${className}KeySchema = z.object({
+  id: z.string(),
+});
+
+export class ${className}Model extends BaseModel<typeof ${className}Schema> {
+  constructor(client: DynamoDBDocumentClient, table: string) {
+    const entity = new Entity(
+      {
+        model: { entity: "${className}", version: "1", service: "app" },
+        attributes: {
+          id: { type: "string", required: true },
+        },
+        indexes: {
+          primary: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: ["id"] },
+          },
+        },
+      },
+      { client, table }
+    );
+    super(entity, ${className}Schema, ${className}KeySchema, client, table);
+  }
+}
+`;
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+export function generateController(
+  name: string,
+  baseDir: string = process.cwd()
+) {
+  const className = toPascalCase(name);
+  const dir = path.join(baseDir, 'src', 'controllers');
+  const filePath = path.join(dir, `${className}Controller.ts`);
+  ensureDir(dir);
+  if (existsSync(filePath)) {
+    throw new Error(`Controller already exists: ${filePath}`);
+  }
+  const modelImport = `${className}Model`;
+  const basePath = `/${name.toLowerCase()}s`;
+  const content = `import { Hono } from "hono";
+import { BaseController } from "@bishop-and-co/dmvc";
+import { ${modelImport} } from "../models/${className}";
+
+export function register${className}Controller(app: Hono) {
+  BaseController.register(app, { model: ${modelImport}, basePath: "${basePath}" });
+}
+`;
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+if (require.main === module) {
+  const [command, type, name] = process.argv.slice(2);
+  if (command !== 'generate' || !type || !name) {
+    console.error('Usage: dmvc generate [model|controller] Name');
+    process.exit(1);
+  }
+  try {
+    if (type === 'model') {
+      const fp = generateModel(name);
+      console.log(`Created model: ${path.relative(process.cwd(), fp)}`);
+    } else if (type === 'controller') {
+      const fp = generateController(name);
+      console.log(`Created controller: ${path.relative(process.cwd(), fp)}`);
+    } else {
+      console.error('Unknown type: ' + type);
+      process.exit(1);
+    }
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './BaseModel';
 export * from './BaseController';
 export * from './QueryService';
 export * from './requireAuth';
+export * from './generator';

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { generateModel, generateController } from '../src/generator';
+
+describe('generators', () => {
+  it('creates model and controller files', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      const modelPath = generateModel('widget', dir);
+      const controllerPath = generateController('widget', dir);
+      expect(existsSync(modelPath)).toBe(true);
+      expect(existsSync(controllerPath)).toBe(true);
+      const modelContent = readFileSync(modelPath, 'utf8');
+      expect(modelContent).toContain('class WidgetModel');
+      const controllerContent = readFileSync(controllerPath, 'utf8');
+      expect(controllerContent).toContain('registerWidgetController');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add CLI to generate model and controller scaffolds
- expose generator utilities and bin entry
- test generator file creation

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2242a9d88321a5456e1361b12e25