### PR TITLE
docs: add generator usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ class UserModel extends BaseModel<typeof UserSchema> {
 
 These hooks run automatically around the respective operations.
 
+## Generator
+
+dmvc ships with a tiny CLI that scaffolds boilerplate models and controllers for you.
+
+```bash
+npx dmvc generate model widget
+# => creates src/models/Widget.ts
+
+npx dmvc generate controller widget
+# => creates src/controllers/WidgetController.ts
+```
+
+The generator creates the `src/models` and `src/controllers` directories if they do not exist and refuses to overwrite existing files.
+Edit the generated files to flesh out schemas, attributes, and any custom logic for your application.
+
 ## Example
 
 A minimal todo application built with dmvc lives in [examples/todo](./examples/todo). It defines a todo model and registers CRUD routes with Hono. The example's `package.json` also exposes scripts to create, read, update, and destroy todos, and includes a `docker-compose.yml` for spinning up a local DynamoDB instance. See its [README](examples/todo/README.md) for setup instructions.

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -1,0 +1,27 @@
+# Generator Example
+
+This example shows how to use the `dmvc` generator to scaffold model and controller files.
+
+## CLI
+
+Run the generator from the root of your project:
+
+```bash
+npx dmvc generate model widget
+npx dmvc generate controller widget
+```
+
+These commands create `src/models/Widget.ts` and `src/controllers/WidgetController.ts`. Edit the generated files to define attributes, validation schemas, and routes for your app.
+
+## Programmatic usage
+
+You can also invoke the generator functions directly:
+
+```ts
+import { generateModel, generateController } from "@bishop-and-co/dmvc";
+
+generateModel("widget");
+generateController("widget");
+```
+
+Running this script will produce the same files in the current working directory.

--- a/examples/generator/index.ts
+++ b/examples/generator/index.ts
@@ -1,0 +1,5 @@
+import { generateModel, generateController } from "@bishop-and-co/dmvc";
+
+// generates src/models/Widget.ts and src/controllers/WidgetController.ts under this directory
+generateModel("widget", __dirname);
+generateController("widget", __dirname);


### PR DESCRIPTION
## Summary
- document generator CLI usage in README
- add generator example for CLI and programmatic use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3235d3cc83219447a87d5944e2bc