### PR TITLE
fix: support npm cache without lock file in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,6 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: package.json
       - run: npm install --no-audit --fund=false
       - run: npm test


### PR DESCRIPTION
## Summary
- fix tests workflow to set `cache-dependency-path` so setup-node caching works without a lock file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa34bb373483218224b6d8dd025171