### PR TITLE
Fix broken workflow badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # dmvc
 
-[![Tests](https://github.com/bishopco/dmvc/actions/workflows/tests.yml/badge.svg)](https://github.com/bishopco/dmvc/actions/workflows/tests.yml)
+[![Tests](https://github.com/bishopandco/dmvc/actions/workflows/tests.yml/badge.svg)](https://github.com/bishopandco/dmvc/actions/workflows/tests.yml)
 
 dmvc provides a minimal model/controller layer for building REST APIs on top of [Hono](https://hono.dev). It pairs [ElectroDB](https://github.com/tywalch/electrodb) for DynamoDB access with [Zod](https://zod.dev) schemas and exposes helpers to quickly register CRUD routes.
 


### PR DESCRIPTION
## Summary
- fix tests status badge link in README to point to current repo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa37bd663c832196c6548a7f195c0d