### PR TITLE
Use model name as ID field in generator

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -17,6 +17,7 @@ function ensureDir(dir: string) {
 
 export function generateModel(name: string, baseDir: string = process.cwd()) {
   const className = toPascalCase(name);
+  const idName = name.toLowerCase();
   const dir = path.join(baseDir, 'src', 'models');
   const filePath = path.join(dir, `${className}.ts`);
   ensureDir(dir);
@@ -29,12 +30,12 @@ import { z } from "zod";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 const ${className}Schema = z.object({
-  id: z.string(),
+  ${idName}: z.string(),
   // define additional attributes here
 });
 
 const ${className}KeySchema = z.object({
-  id: z.string(),
+  ${idName}: z.string(),
 });
 
 export class ${className}Model extends BaseModel<typeof ${className}Schema> {
@@ -43,12 +44,12 @@ export class ${className}Model extends BaseModel<typeof ${className}Schema> {
       {
         model: { entity: "${className}", version: "1", service: "app" },
         attributes: {
-          id: { type: "string", required: true },
+          ${idName}: { type: "string", required: true },
         },
         indexes: {
           primary: {
-            pk: { field: "pk", composite: ["id"] },
-            sk: { field: "sk", composite: ["id"] },
+            pk: { field: "pk", composite: ["${idName}"] },
+            sk: { field: "sk", composite: ["${idName}"] },
           },
         },
       },

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -14,6 +14,9 @@ describe('generators', () => {
       expect(existsSync(controllerPath)).toBe(true);
       const modelContent = readFileSync(modelPath, 'utf8');
       expect(modelContent).toContain('class WidgetModel');
+      expect(modelContent).toContain('widget: z.string()');
+      expect(modelContent).not.toContain('id: z.string()');
+      expect(modelContent).toContain('composite: ["widget"]');
       const controllerContent = readFileSync(controllerPath, 'utf8');
       expect(controllerContent).toContain('registerWidgetController');
     } finally {


### PR DESCRIPTION
## Summary
- Use model name instead of generic `id` when generating ElectroDB models
- Add test expectations for dynamic id field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a55f2bc83219ddf13afb186da50