### PR TITLE
docs: use model name as identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install @bishop-and-co/dmvc hono zod electrodb @aws-sdk/client-dynamodb @aws
 
 ## Defining a model
 
-Create a model by extending `BaseModel`. The model wires up a Zod schema and ElectroDB entity:
+Create a model by extending `BaseModel`. ElectroDB conventions use the model name itself as the identifier attribute, so avoid generic `id` or `modelId` fields. The model wires up a Zod schema and ElectroDB entity:
 
 ```ts
 import { BaseModel } from "@bishop-and-co/dmvc";
@@ -33,7 +33,7 @@ import { Entity } from "electrodb";
 import { z } from "zod";
 
 const UserSchema = z.object({
-  userId: z.string(),
+  user: z.string(), // model id
   name: z.string().optional(),
 });
 
@@ -41,12 +41,12 @@ export class UserModel extends BaseModel<typeof UserSchema> {
   constructor(client: any, table: string) {
     super(client, table);
     this.schema = UserSchema;
-    this.keySchema = UserSchema.pick({ userId: true });
+    this.keySchema = UserSchema.pick({ user: true });
     this.entity = new Entity(
       {
         model: { entity: "User", version: "1", service: "app" },
-        attributes: { userId: { type: "string", required: true }, name: { type: "string" } },
-        indexes: { primary: { pk: { field: "pk", composite: ["userId"] } } },
+        attributes: { user: { type: "string", required: true }, name: { type: "string" } },
+        indexes: { primary: { pk: { field: "pk", composite: ["user"] } } },
       },
       { client, table }
     );
@@ -104,7 +104,7 @@ app.use("*", async (c, next) => {
   const token = c.req.header("Authorization");
   if (token) {
     // decode token and set the user on the context
-    c.set("user", { id: "u123", role: "admin" });
+    c.set("user", { user: "u123", role: "admin" });
   }
   await next();
 });

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -29,9 +29,9 @@ With DynamoDB running you can exercise the model directly from the command line:
 
 ```bash
 npm run create
-npm run read <id>
-npm run update <id>
-npm run destroy <id>
+npm run read <todo>
+npm run update <todo>
+npm run destroy <todo>
 npm run list [cursor] [limit]
 ```
 

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -8,14 +8,14 @@ import { z } from 'zod';
 
 // define the todo schema
 const TodoSchema = z.object({
-  id: z.string(),
+  todo: z.string(),
   title: z.string(),
   completed: z.boolean().default(false),
 });
 
 // schema for composite keys with defaults
 const TodoKeySchema = z.object({
-  id: z.string(),
+  todo: z.string(),
   type: z.literal('todo').default('todo'),
 });
 
@@ -26,7 +26,7 @@ class TodoModel extends BaseModel<typeof TodoSchema> {
       {
         model: { entity: 'Todo', version: '1', service: 'app' },
         attributes: {
-          id: { type: 'string', required: true },
+          todo: { type: 'string', required: true },
           title: { type: 'string', required: true },
           completed: { type: 'boolean', default: false },
           type: { type: 'string', required: true, default: 'todo' },
@@ -34,17 +34,17 @@ class TodoModel extends BaseModel<typeof TodoSchema> {
         indexes: {
           primary: {
             pk: { field: 'pk', composite: ['type'] },
-            sk: { field: 'sk', composite: ['id'] },
+            sk: { field: 'sk', composite: ['todo'] },
           },
           byTitle: {
             index: 'gsi1pk-gsi1sk-index',
             pk: { field: 'gsi1pk', composite: ['title'] },
-            sk: { field: 'gsi1sk', composite: ['id'] },
+            sk: { field: 'gsi1sk', composite: ['todo'] },
           },
           byCompleted: {
             index: 'gsi2pk-gsi2sk-index',
             pk: { field: 'gsi2pk', composite: ['completed'] },
-            sk: { field: 'gsi2sk', composite: ['id'] },
+            sk: { field: 'gsi2sk', composite: ['todo'] },
           },
         },
       },

--- a/examples/todo/scripts.ts
+++ b/examples/todo/scripts.ts
@@ -72,25 +72,25 @@ async function main() {
     await ensureTable();
     switch (command) {
       case 'create': {
-        const todo = await TodoModel.create({ id: randomUUID(), title: 'demo todo' });
+        const todo = await TodoModel.create({ todo: randomUUID(), title: 'demo todo' });
         console.log(todo);
         break;
       }
       case 'read': {
-        if (!arg1) throw new Error('ID required');
-        const todo = await TodoModel.get({ id: arg1 });
+        if (!arg1) throw new Error('todo required');
+        const todo = await TodoModel.get({ todo: arg1 });
         console.log(todo);
         break;
       }
       case 'update': {
-        if (!arg1) throw new Error('ID required');
-        const todo = await TodoModel.update({ id: arg1, completed: true });
+        if (!arg1) throw new Error('todo required');
+        const todo = await TodoModel.update({ todo: arg1, completed: true });
         console.log(todo);
         break;
       }
       case 'destroy': {
-        if (!arg1) throw new Error('ID required');
-        const result = await TodoModel.delete({ id: arg1 });
+        if (!arg1) throw new Error('todo required');
+        const result = await TodoModel.delete({ todo: arg1 });
         console.log(result);
         break;
       }
@@ -103,7 +103,7 @@ async function main() {
       }
       default:
         console.log(
-          'Usage: tsx scripts.ts <create|read|update|destroy|list> [id|cursor] [limit]'
+          'Usage: tsx scripts.ts <create|read|update|destroy|list> [todo|cursor] [limit]'
         );
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- align examples and docs with ElectroDB convention of using the model name as the primary identifier
- adjust todo example and auth snippet to drop generic `id` fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf91729608321bf16f68812493c6e