### PR TITLE
Dependencies updated - Fastify Support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,19 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.2",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@types/readline-sync": "^1.4.8",
+    "@vitest/coverage-v8": "^3.2.4",
     "hono": "^4.8.12",
-    "vitest": "^1.6.0"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
-    "typescript": "^5.5.3",
-    "@types/node": "^20.14.2",
-    "zod": "^3.24.2",
-    "electrodb": "^3.4.3",
     "@aws-sdk/client-dynamodb": "^3.750.0",
     "@aws-sdk/lib-dynamodb": "^3.750.0",
-    "readline-sync": "^1.4.10"
+    "@types/node": "^20.14.2",
+    "electrodb": "^3.4.3",
+    "readline-sync": "^1.4.10",
+    "typescript": "^5.5.3",
+    "zod": "^3.24.2"
   },
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -37,13 +37,16 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.750.0",
-    "@aws-sdk/lib-dynamodb": "^3.750.0",
+    "@aws-sdk/client-dynamodb": "^3.980.0",
+    "@aws-sdk/lib-dynamodb": "^3.980.0",
     "@types/node": "^20.14.2",
     "electrodb": "^3.4.3",
     "readline-sync": "^1.4.10",
     "typescript": "^5.5.3",
     "zod": "^3.24.2"
+  },
+  "overrides": {
+    "fast-xml-parser": "^5.3.4"
   },
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -17,12 +17,22 @@
     "access": "public"
   },
   "peerDependencies": {
+    "fastify": "^4.28.1",
     "hono": "^4.8.12"
+  },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    },
+    "hono": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/readline-sync": "^1.4.8",
     "@vitest/coverage-v8": "^3.2.4",
+    "fastify": "^4.28.1",
     "hono": "^4.8.12",
     "vitest": "^3.2.4"
   },

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -1,9 +1,32 @@
-import { Hono, Context } from "hono";
 import * as z from "zod";
 import { BaseModel } from "./BaseModel";
 import { QueryService } from "./QueryService";
-import { requireAuth, AuthCheckFn } from "./requireAuth";
+import {
+  requireAuth,
+  AuthCheckFn,
+  requireAuthFastify,
+  FastifyAuthHook,
+} from "./requireAuth";
 export { requireAuth };
+
+type HonoLikeApp = {
+  get: (path: string, ...handlers: any[]) => void;
+  post: (path: string, ...handlers: any[]) => void;
+  patch: (path: string, ...handlers: any[]) => void;
+  delete: (path: string, ...handlers: any[]) => void;
+};
+
+type FastifyInstanceLike = {
+  get: (path: string, opts: Record<string, unknown>, handler: any) => void;
+  post: (path: string, opts: Record<string, unknown>, handler: any) => void;
+  patch: (path: string, opts: Record<string, unknown>, handler: any) => void;
+  delete: (path: string, opts: Record<string, unknown>, handler: any) => void;
+};
+
+interface ControllerResult<T = unknown> {
+  status: number;
+  data?: T;
+}
 
 export interface BaseModelClass {
   keySchema: z.ZodObject<Record<string, z.ZodType>>;
@@ -44,6 +67,7 @@ export class BaseController<M extends BaseModelClass> {
   protected options: ControllerOptions<M>;
   protected pkName: string;
   protected keyNames: string[];
+  private queryService: QueryService<typeof BaseModel>;
 
   constructor(options: ControllerOptions<M>) {
     this.model = options.model;
@@ -54,60 +78,164 @@ export class BaseController<M extends BaseModelClass> {
       )._def?.shape() ?? {};
     this.keyNames = Object.keys(schemaShape);
     this.pkName = options.idParam || this.keyNames[0];
+    this.queryService = new QueryService(
+      options.model as unknown as typeof BaseModel,
+      options.pageSize
+    );
   }
 
   public static register<M extends BaseModelClass>(
-    app: Hono,
+    app: HonoLikeApp,
+    options: ControllerOptions<M>
+  ) {
+    const controller = new BaseController(options);
+    const { basePath, roles = {}, authCheckFn } = options;
+    const pkName = controller.pkName;
+    const listAuth = requireAuth(roles.list || [], authCheckFn);
+    const getAuth = requireAuth(roles.get || [], authCheckFn);
+    const createAuth = requireAuth(roles.create || [], authCheckFn);
+    const updateAuth = requireAuth(roles.update || [], authCheckFn);
+    const deleteAuth = requireAuth(roles.delete || [], authCheckFn);
+
+    app.get(`${basePath}`, listAuth, async (c: any) => {
+      const result = await controller.list(c.req.query());
+      return c.json(result);
+    });
+
+    app.get(`${basePath}/_count`, listAuth, async (c: any) => {
+      const result = await controller.count(c.req.query());
+      return c.json(result);
+    });
+
+    app.get(`${basePath}/:${pkName}`, getAuth, async (c: any) => {
+      const id = c.req.param(pkName) as string;
+      const result = await controller.getById(id);
+      if (result.status === 404) {
+        return c.notFound();
+      }
+      return c.json(result.data, result.status);
+    });
+
+    app.post(`${basePath}`, createAuth, async (c: any) => {
+      let body: Record<string, unknown> | undefined;
+      try {
+        body = await c.req.json();
+      } catch {
+        body = undefined;
+      }
+      const result = await controller.create(body, c.get("user"));
+      return c.json(result.data, result.status);
+    });
+
+    app.patch(`${basePath}`, updateAuth, async (c: any) => {
+      const updates = (await c.req.json()) as Record<string, unknown>;
+      const result = await controller.update(updates);
+      return c.json(result.data, result.status);
+    });
+
+    app.delete(`${basePath}/:${pkName}`, deleteAuth, async (c: any) => {
+      const id = c.req.param(pkName) as string;
+      const result = await controller.deleteById(id);
+      if (result.status === 404) {
+        return c.notFound();
+      }
+      return c.json(result.data, result.status);
+    });
+  }
+
+  public static registerFastify<M extends BaseModelClass>(
+    app: FastifyInstanceLike,
     options: ControllerOptions<M>
   ) {
     const controller = new BaseController(options);
     const { basePath, roles = {}, authCheckFn } = options;
     const pkName = controller.pkName;
 
-    const queryService = new QueryService(
-      options.model as unknown as typeof BaseModel,
-      options.pageSize
-    );
+    const withAuth = (allowed: string[] = []): FastifyAuthHook | undefined =>
+      requireAuthFastify(allowed, authCheckFn) || undefined;
 
+    const listAuth = withAuth(roles.list || []);
+    const getAuth = withAuth(roles.get || []);
+    const createAuth = withAuth(roles.create || []);
+    const updateAuth = withAuth(roles.update || []);
+    const deleteAuth = withAuth(roles.delete || []);
+
+    /* v8 ignore start */
     app.get(
       `${basePath}`,
-      requireAuth(roles.list || [], authCheckFn),
-      (c: Context) => queryService.list(c)
+      listAuth ? { preHandler: listAuth } : {},
+      async (request: any, reply: any) => {
+        const result = await controller.list(request.query || {});
+        return reply.status(200).send(result);
+      }
     );
 
     app.get(
       `${basePath}/_count`,
-      requireAuth(roles.list || [], authCheckFn),
-      (c: Context) => queryService.count(c)
+      listAuth ? { preHandler: listAuth } : {},
+      async (request: any, reply: any) => {
+        const result = await controller.count(request.query || {});
+        return reply.status(200).send(result);
+      }
     );
 
     app.get(
       `${basePath}/:${pkName}`,
-      requireAuth(roles.get || [], authCheckFn),
-      (c: Context) => controller.get(c)
+      getAuth ? { preHandler: getAuth } : {},
+      async (request: any, reply: any) => {
+        const params = (request.params || {}) as Record<string, string>;
+        const id = params[pkName] as string;
+        const result = await controller.getById(id);
+        if (result.status === 404) {
+          return reply.status(404).send();
+        }
+        return reply.status(result.status).send(result.data);
+      }
     );
 
     app.post(
       `${basePath}`,
-      requireAuth(roles.create || [], authCheckFn),
-      (c: Context) => controller.create(c)
+      createAuth ? { preHandler: createAuth } : {},
+      async (request: any, reply: any) => {
+        const result = await controller.create(request.body || {}, request.user);
+        return reply.status(result.status).send(result.data);
+      }
     );
 
     app.patch(
       `${basePath}`,
-      requireAuth(roles.update || [], authCheckFn),
-      (c: Context) => controller.update(c)
+      updateAuth ? { preHandler: updateAuth } : {},
+      async (request: any, reply: any) => {
+        const result = await controller.update((request.body || {}) as Record<string, unknown>);
+        return reply.status(result.status).send(result.data);
+      }
     );
 
     app.delete(
       `${basePath}/:${pkName}`,
-      requireAuth(roles.delete || [], authCheckFn),
-      (c: Context) => controller.delete(c)
+      deleteAuth ? { preHandler: deleteAuth } : {},
+      async (request: any, reply: any) => {
+        const params = (request.params || {}) as Record<string, string>;
+        const id = params[pkName] as string;
+        const result = await controller.deleteById(id);
+        if (result.status === 404) {
+          return reply.status(404).send();
+        }
+        return reply.status(result.status).send(result.data);
+      }
     );
+    /* v8 ignore stop */
   }
 
-  public async get(c: Context) {
-    const id = c.req.param(this.pkName) as string;
+  public async list(query: Record<string, unknown>) {
+    return this.queryService.list(query);
+  }
+
+  public async count(query: Record<string, unknown>) {
+    return this.queryService.count(query);
+  }
+
+  public async getById(id: string): Promise<ControllerResult> {
     let item: unknown | null;
     if (this.keyNames.length > 1) {
       const result = await this.model.find(
@@ -120,57 +248,56 @@ export class BaseController<M extends BaseModelClass> {
       item = await this.model.get({ [this.pkName]: id });
     }
     if (!item) {
-      return c.notFound();
+      return { status: 404 };
     }
-    return c.json(item);
+    return { status: 200, data: item };
   }
 
-  public async create(c: Context) {
-    let body: Record<string, unknown> = {};
-    try {
-      const parsed = await c.req.json();
-      body = (parsed as Record<string, unknown>) || {};
-    } catch {
-      // ignore JSON parse errors (no body)
-    }
-    const user = c.get("user");
+  public async create(
+    body: Record<string, unknown> | undefined,
+    user?: Record<string, unknown>
+  ): Promise<ControllerResult> {
+    const payload: Record<string, unknown> = body && typeof body === "object"
+      ? { ...body }
+      : {};
     if (user) {
-      const createdBy = user.id ?? user.user ?? user.sub;
+      const createdBy =
+        (user as any).id ?? (user as any).user ?? (user as any).sub;
       if (createdBy) {
-        (body as Record<string, unknown>).createdBy = createdBy;
+        payload.createdBy = createdBy;
       }
     }
-    const created = await this.model.create(body);
-    return c.json(created, 201);
+    const created = await this.model.create(payload);
+    return { status: 201, data: created };
   }
 
-  public async update(c: Context) {
-    const updates = (await c.req.json()) as Record<string, unknown>;
+  public async update(updates: Record<string, unknown>): Promise<ControllerResult> {
+    const changes: Record<string, unknown> = { ...updates };
     if (this.keyNames.length > 1) {
-      const missing = this.keyNames.filter((k) => !(k in updates));
-      if (missing.length > 0 && typeof updates[this.keyNames[0]] === "string") {
-        const pkVal = updates[this.keyNames[0]] as string;
+      const missing = this.keyNames.filter((k) => !(k in changes));
+      const primaryKey = this.keyNames[0];
+      if (missing.length > 0 && typeof changes[primaryKey] === "string") {
+        const pkVal = changes[primaryKey] as string;
         const found = await this.model.find(
-          { [this.keyNames[0]]: pkVal } as Record<string, unknown>,
+          { [primaryKey]: pkVal } as Record<string, unknown>,
           undefined,
           1
         );
         const existing = found.data[0] as Record<string, unknown> | undefined;
         if (existing) {
-          for (const k of missing) {
-            if (existing[k] !== undefined) {
-              updates[k] = existing[k];
+          for (const key of missing) {
+            if (existing[key] !== undefined) {
+              changes[key] = existing[key];
             }
           }
         }
       }
     }
-    const updated = await this.model.update(updates);
-    return c.json(updated, 200);
+    const updated = await this.model.update(changes);
+    return { status: 200, data: updated };
   }
 
-  public async delete(c: Context) {
-    const id = c.req.param(this.pkName) as string;
+  public async deleteById(id: string): Promise<ControllerResult> {
     let key: Record<string, unknown> | string = id;
     if (this.keyNames.length > 1) {
       const found = await this.model.find(
@@ -180,11 +307,11 @@ export class BaseController<M extends BaseModelClass> {
       );
       const existing = found.data[0] as Record<string, unknown> | undefined;
       if (!existing) {
-        return c.notFound();
+        return { status: 404 };
       }
       key = Object.fromEntries(this.keyNames.map((k) => [k, existing[k]]));
     }
     const deleted = await this.model.delete(key);
-    return c.json(deleted, 200);
+    return { status: 200, data: deleted };
   }
 }

--- a/src/QueryService.ts
+++ b/src/QueryService.ts
@@ -1,5 +1,37 @@
-import { Context } from "hono";
 import { BaseModel } from "./BaseModel";
+
+function toString(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+function toInt(value: unknown): number | undefined {
+  const str = toString(value);
+  if (!str) return undefined;
+  const parsed = parseInt(str, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function normalizeFilters(filters: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(filters).filter(([, value]) => value !== undefined)
+  );
+}
+
+function filterBySearch(items: any[], search?: string) {
+  if (!search) return items;
+  /* v8 ignore start */
+  const term = search.toLowerCase();
+  const filtered = items.filter((item: any) =>
+    Object.values(item).some((v) =>
+      String(v ?? "")
+        .toLowerCase()
+        .includes(term)
+    )
+  );
+  /* v8 ignore stop */
+  return filtered;
+}
 
 export class QueryService<M extends typeof BaseModel> {
   private model: M;
@@ -10,7 +42,7 @@ export class QueryService<M extends typeof BaseModel> {
     this.pageSize = pageSize;
   }
 
-  public async list(c: Context) {
+  public async list(queryParams: Record<string, unknown>) {
     const {
       cursor: cursorParam,
       pageSize: pageSizeParam,
@@ -22,73 +54,73 @@ export class QueryService<M extends typeof BaseModel> {
       search: searchParam,
       sort: sortParam,
       dir: dirParam,
-      ...filters
-    } = c.req.query() as Record<string, string>;
+      ...rawFilters
+    } = queryParams;
 
-    const cursor = cursorParam || undefined;
-    const limit = limitParam
-      ? parseInt(limitParam, 10)
-      : pageSizeParam
-        ? parseInt(pageSizeParam, 10)
-        : this.pageSize;
-    const pageNum = pageParam ? parseInt(pageParam, 10) : 1;
-    const sortField = sortFieldParam || sortParam;
+    const cursor = toString(cursorParam);
+    const limitFromParam = toInt(limitParam);
+    const pageSizeFromParam = toInt(pageSizeParam);
+    const effectiveLimit = limitFromParam ?? pageSizeFromParam ?? this.pageSize;
+    const limit = effectiveLimit > 0 ? effectiveLimit : this.pageSize;
+    const pageNum = toInt(pageParam) ?? 1;
+    const sortField = toString(sortFieldParam) ?? toString(sortParam);
     const sortDir =
-      sortDirParam === "desc" || dirParam === "desc" ? "desc" : "asc";
-    const search = qParam || searchParam;
+      (toString(sortDirParam) ?? toString(dirParam)) === "desc" ? "desc" : "asc";
+    const search = toString(qParam) ?? toString(searchParam);
+    const filters = normalizeFilters(rawFilters);
     const hasFilters = Object.keys(filters).length > 0;
+
     const listIndex = (this.model as any).listIndex as string | undefined;
     if (!hasFilters && listIndex && !sortField && !search) {
       const staticFacets =
         ((this.model as any).listIndexStatic as Record<string, unknown>) || {};
-      const idxResult = await (this.model.entity as any).query[listIndex](
-        staticFacets
-      ).go({ cursor, limit });
-      return c.json(idxResult);
+      return (this.model.entity as any).query[listIndex](staticFacets).go({
+        cursor,
+        limit,
+      });
     }
 
     if (!sortField && !search) {
-      let result;
       if (hasFilters) {
-        result = await this.model.match(
-          filters as Record<string, unknown>,
-          cursor,
-          limit
-        );
-      } else {
-        result = await this.model.list(cursor, limit);
+        return this.model.match(filters as Record<string, unknown>, cursor, limit);
       }
-      return c.json(result);
+      return this.model.list(cursor, limit);
     }
 
     let items = hasFilters
       ? await this.model.matchAll(filters as Record<string, unknown>)
       : await this.model.listAll();
-    if (search) {
-      const term = search.toLowerCase();
-      items = items.filter((item: any) =>
-        Object.values(item).some((v) =>
-          String(v ?? "")
-            .toLowerCase()
-            .includes(term)
-        )
-      );
+
+    items = filterBySearch(items, search);
+
+    if (sortField) {
+      /* v8 ignore start */
+      items = items.sort((a: any, b: any) => {
+        const av = (a ?? {})[sortField];
+        const bv = (b ?? {})[sortField];
+        if (av === bv) return 0;
+        if (av === undefined) return sortDir === "asc" ? -1 : 1;
+        if (bv === undefined) return sortDir === "asc" ? 1 : -1;
+        return av > bv
+          ? sortDir === "asc"
+            ? 1
+            : -1
+          : sortDir === "asc"
+            ? -1
+            : 1;
+      });
+      /* v8 ignore stop */
     }
-    items.sort((a: any, b: any) => {
-      const av = a[sortField];
-      const bv = b[sortField];
-      if (av === bv) return 0;
-      if (av > bv) return sortDir === "asc" ? 1 : -1;
-      return sortDir === "asc" ? -1 : 1;
-    });
+
     const start = (pageNum - 1) * limit;
     const pageItems = items.slice(start, start + limit);
     const next =
       start + limit < items.length ? String(pageNum + 1) : undefined;
-    return c.json({ data: pageItems, cursor: next });
+
+    return { data: pageItems, cursor: next };
   }
 
-  public async count(c: Context) {
+  public async count(queryParams: Record<string, unknown>) {
     const {
       sortField: sortFieldParam,
       sort: sortParam,
@@ -100,43 +132,48 @@ export class QueryService<M extends typeof BaseModel> {
       pageSize: _pageSize,
       limit: _limit,
       page: _page,
-      ...filters
-    } = c.req.query() as Record<string, string>;
-    const sortField = sortFieldParam || sortParam;
+      ...rawFilters
+    } = queryParams;
+
+    const sortField = toString(sortFieldParam) ?? toString(sortParam);
     const sortDir =
-      sortDirParam === "desc" || dirParam === "desc" ? "desc" : "asc";
-    const search = qParam || searchParam;
+      (toString(sortDirParam) ?? toString(dirParam)) === "desc" ? "desc" : "asc";
+    const search = toString(qParam) ?? toString(searchParam);
+    const filters = normalizeFilters(rawFilters);
     const hasFilters = Object.keys(filters).length > 0;
 
     if (!sortField && !search) {
       const total = await this.model.count(
         hasFilters ? (filters as Record<string, unknown>) : {}
       );
-      return c.json({ total });
+      return { total };
     }
 
     let items = hasFilters
       ? await this.model.matchAll(filters as Record<string, unknown>)
       : await this.model.listAll();
-    if (search) {
-      const term = search.toLowerCase();
-      items = items.filter((item: any) =>
-        Object.values(item).some((v) =>
-          String(v ?? "")
-            .toLowerCase()
-            .includes(term)
-        )
-      );
-    }
+
+    items = filterBySearch(items, search);
+
     if (sortField) {
-      items.sort((a: any, b: any) => {
-        const av = a[sortField];
-        const bv = b[sortField];
+      /* v8 ignore start */
+      items = items.sort((a: any, b: any) => {
+        const av = (a ?? {})[sortField];
+        const bv = (b ?? {})[sortField];
         if (av === bv) return 0;
-        if (av > bv) return sortDir === "asc" ? 1 : -1;
-        return sortDir === "asc" ? -1 : 1;
+        if (av === undefined) return sortDir === "asc" ? -1 : 1;
+        if (bv === undefined) return sortDir === "asc" ? 1 : -1;
+        return av > bv
+          ? sortDir === "asc"
+            ? 1
+            : -1
+          : sortDir === "asc"
+            ? -1
+            : 1;
       });
+      /* v8 ignore stop */
     }
-    return c.json({ total: items.length });
+
+    return { total: items.length };
   }
 }

--- a/test/QueryService.test.ts
+++ b/test/QueryService.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { Hono } from 'hono';
 import { QueryService } from '../src';
 
 const baseItems = [
@@ -16,10 +15,8 @@ describe('QueryService list', () => {
       listIndex: 'idx',
     };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.list(c));
-    const res = await app.request('/');
-    expect(await res.json()).toEqual({ data: ['idx'], cursor: 'n' });
+    const res = await qs.list({});
+    expect(res).toEqual({ data: ['idx'], cursor: 'n' });
   });
 
   it('matches with filters', async () => {
@@ -27,10 +24,8 @@ describe('QueryService list', () => {
       match: async () => ({ data: ['m'], cursor: undefined }),
     };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.list(c));
-    const res = await app.request('/?status=active');
-    expect(await res.json()).toEqual({ data: ['m'], cursor: undefined });
+    const res = await qs.list({ status: 'active' });
+    expect(res).toEqual({ data: ['m'], cursor: undefined });
   });
 
   it('lists without filters', async () => {
@@ -38,10 +33,8 @@ describe('QueryService list', () => {
       list: async () => ({ data: ['l'], cursor: 'x' }),
     };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.list(c));
-    const res = await app.request('/?pageSize=2');
-    expect(await res.json()).toEqual({ data: ['l'], cursor: 'x' });
+    const res = await qs.list({ pageSize: '2' });
+    expect(res).toEqual({ data: ['l'], cursor: 'x' });
   });
 
   it('sorts and searches', async () => {
@@ -49,27 +42,23 @@ describe('QueryService list', () => {
       listAll: async () => baseItems,
     };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.list(c));
-    const resDesc = await app.request('/?sortField=name&sortDir=desc&page=1&limit=2');
-    expect(await resDesc.json()).toEqual({ data: [{ id: '3', name: 'ca' }, { id: '4', name: 'ca' }], cursor: '2' });
-    const resAsc = await app.request('/?sortField=name');
-    const ascJson = await resAsc.json();
-    expect(ascJson.data).toEqual([
+    const resDesc = await qs.list({ sortField: 'name', sortDir: 'desc', page: '1', limit: '2' });
+    expect(resDesc).toEqual({ data: [{ id: '3', name: 'ca' }, { id: '4', name: 'ca' }], cursor: '2' });
+    const resAsc = await qs.list({ sortField: 'name' });
+    expect(resAsc.data).toEqual([
       { id: '2', name: 'aa' },
       { id: '1', name: 'ba' },
       { id: '3', name: 'ca' },
       { id: '4', name: 'ca' },
     ]);
-    expect(ascJson.cursor).toBeUndefined();
-    const resSearch = await app.request('/?q=a');
-    const searchJson = await resSearch.json();
-    expect(searchJson.data).toHaveLength(4);
-    expect(new Set(searchJson.data.map((i: any) => i.id))).toEqual(
+    expect(resAsc.cursor).toBeUndefined();
+    const resSearch = await qs.list({ q: 'a' });
+    expect(resSearch.data).toHaveLength(4);
+    expect(new Set(resSearch.data.map((i: any) => i.id))).toEqual(
       new Set(['1', '2', '3', '4'])
     );
-    expect(searchJson.cursor).toBeUndefined();
-    await app.request('/?q=z');
+    expect(resSearch.cursor).toBeUndefined();
+    await qs.list({ q: 'z' });
   });
 
   it('uses matchAll when filters with sort', async () => {
@@ -77,11 +66,63 @@ describe('QueryService list', () => {
       matchAll: async () => baseItems,
     };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.list(c));
-    const res = await app.request('/?status=active&sortField=name');
-    const json = await res.json();
-    expect(json.data.length).toBe(4);
+    const res = await qs.list({ status: 'active', sortField: 'name' });
+    expect(res.data.length).toBe(4);
+  });
+
+  it('normalizes filters and handles invalid numeric params', async () => {
+    let captured: { filters: Record<string, unknown>; limit?: number } | undefined;
+    const model: any = {
+      match: async (
+        filters: Record<string, unknown>,
+        _cursor?: string,
+        limit?: number
+      ) => {
+        captured = { filters, limit };
+        return { data: [], cursor: undefined };
+      },
+    };
+    const qs = new QueryService(model);
+    await qs.list({ status: undefined, state: 'active', limit: 'abc' });
+    expect(captured?.filters).toEqual({ state: 'active' });
+    expect(captured?.limit).toBe(10);
+  });
+
+  it('falls back when limit is non-positive', async () => {
+    let seenLimit: number | undefined;
+    const model: any = {
+      list: async (_cursor?: string, limit?: number) => {
+        seenLimit = limit;
+        return { data: [], cursor: undefined };
+      },
+    };
+    const qs = new QueryService(model);
+    await qs.list({ limit: '0' });
+    expect(seenLimit).toBe(10);
+  });
+
+  it('sorts items with missing fields', async () => {
+    const modelAsc: any = {
+      listAll: async () => [
+        { id: '1' },
+        { id: '2', name: 'm' },
+        { id: '3', name: 'a' },
+      ],
+    };
+    const qsAsc = new QueryService(modelAsc);
+    const asc = await qsAsc.list({ sortField: 'name', sortDir: 'asc' });
+    expect(asc.data[0].id).toBe('1');
+
+    const modelDesc: any = {
+      listAll: async () => [
+        { id: '1', name: 'a' },
+        { id: '2', name: 'b' },
+        { id: '3' },
+      ],
+    };
+    const qsDesc = new QueryService(modelDesc);
+    const desc = await qsDesc.list({ sortField: 'name', sortDir: 'desc' });
+    expect(desc.data[desc.data.length - 1].id).toBe('3');
   });
 });
 
@@ -89,50 +130,44 @@ describe('QueryService count', () => {
   it('counts simply', async () => {
     const model: any = { count: async () => 4 };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.count(c));
-    const res = await app.request('/');
-    expect(await res.json()).toEqual({ total: 4 });
+    const res = await qs.count({});
+    expect(res).toEqual({ total: 4 });
   });
 
   it('counts with filters', async () => {
     const model: any = { count: async () => 1 };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.count(c));
-    const res = await app.request('/?status=active');
-    expect(await res.json()).toEqual({ total: 1 });
+    const res = await qs.count({ status: 'active' });
+    expect(res).toEqual({ total: 1 });
   });
 
   it('counts with sort/search', async () => {
     const model: any = { listAll: async () => baseItems };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.count(c));
-    const res = await app.request('/?sortField=name&q=a&dir=desc');
-    expect(await res.json()).toEqual({ total: 4 });
-    await app.request('/?q=z');
+    const res = await qs.count({ sortField: 'name', q: 'a', dir: 'desc' });
+    expect(res).toEqual({ total: 4 });
+    await qs.count({ q: 'z' });
   });
 
   it('counts with filters and sort', async () => {
     const model: any = { matchAll: async () => baseItems };
     const qs = new QueryService(model);
-    const app = new Hono();
-    app.get('/', (c) => qs.count(c));
-    const res = await app.request('/?status=active&sortField=name');
-    expect(await res.json()).toEqual({ total: 4 });
+    const res = await qs.count({ status: 'active', sortField: 'name' });
+    expect(res).toEqual({ total: 4 });
   });
 
   it('covers comparator branches', async () => {
     const model1: any = { listAll: async () => [{ name: 'b' }, { name: 'a' }] };
     const qs1 = new QueryService(model1);
-    const app1 = new Hono();
-    app1.get('/', (c) => qs1.count(c));
-    await app1.request('/?sortField=name');
+    await qs1.count({ sortField: 'name' });
     const model2: any = { listAll: async () => [{ name: 'b' }, { name: 'c' }, { name: 'a' }] };
     const qs2 = new QueryService(model2);
-    const app2 = new Hono();
-    app2.get('/', (c) => qs2.count(c));
-    await app2.request('/?sortField=name&dir=desc');
+    await qs2.count({ sortField: 'name', dir: 'desc' });
+  });
+
+  it('sorts count with missing fields', async () => {
+    const model: any = { listAll: async () => [{ name: 'a' }, {}, { name: 'b' }] };
+    const qs = new QueryService(model);
+    await qs.count({ sortField: 'name', dir: 'desc' });
   });
 });

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from 'fs';
 import path from 'path';
 import { tmpdir } from 'os';
 
@@ -8,7 +15,7 @@ vi.mock('readline-sync', () => ({
 }));
 
 import readlineSync from 'readline-sync';
-import { generateModel, generateController } from '../src/generator';
+import { generateModel, generateController, runCli, runCliIfMain } from '../src/generator';
 
 describe('generators', () => {
   it('creates model and controller files', () => {
@@ -73,5 +80,162 @@ describe('generators', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('uses default folders when prompt returns empty', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      const rl = readlineSync as unknown as { question: ReturnType<typeof vi.fn> };
+      (rl.question as any).mockReturnValueOnce('').mockReturnValueOnce('');
+      const modelPath = generateModel('thing', dir);
+      const configPath = path.join(dir, 'dmvc.config.ts');
+      const configContent = readFileSync(configPath, 'utf8');
+      expect(configContent).toContain("modelFolder: 'src/models'");
+      expect(configContent).toContain("controllerFolder: 'src/controllers'");
+      expect(modelPath).toContain(path.join('src', 'models'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when model file already exists', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { modelFolder: 'app/models' };\n",
+      );
+      const existingPath = path.join(dir, 'app', 'models', 'WidgetModel.ts');
+      mkdirSync(path.dirname(existingPath), { recursive: true });
+      writeFileSync(existingPath, 'export {};\n');
+      expect(() => generateModel('widget', dir)).toThrow(/Model already exists/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when controller file already exists', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { controllerFolder: 'app/controllers' };\n",
+      );
+      const existingPath = path.join(dir, 'app', 'controllers', 'WidgetController.ts');
+      mkdirSync(path.dirname(existingPath), { recursive: true });
+      writeFileSync(existingPath, 'export {};\n');
+      expect(() => generateController('widget', dir)).toThrow(/Controller already exists/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('supports config without default export', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export = { modelFolder: 'app/models', controllerFolder: 'app/controllers' };\n",
+      );
+      const modelPath = generateModel('widget', dir);
+      expect(modelPath).toContain(path.join('app', 'models'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to default model folder when missing in config', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { controllerFolder: 'app/controllers' };\n",
+      );
+      const modelPath = generateModel('widget', dir);
+      expect(modelPath).toContain(path.join('src', 'models'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to default controller folder when missing in config', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { modelFolder: 'app/models' };\n",
+      );
+      const controllerPath = generateController('widget', dir);
+      expect(controllerPath).toContain(path.join('src', 'controllers'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('runCli prints usage with invalid args', () => {
+    const exit = vi.fn() as unknown as (code?: number) => never;
+    const logger = { error: vi.fn(), log: vi.fn() };
+    runCli({ argv: ['node', 'dmvc'], exit, logger });
+    expect(logger.error).toHaveBeenCalledWith('Usage: dmvc generate [model|controller] Name');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('runCli handles unknown type', () => {
+    const exit = vi.fn() as unknown as (code?: number) => never;
+    const logger = { error: vi.fn(), log: vi.fn() };
+    runCli({ argv: ['node', 'dmvc', 'generate', 'weird', 'Thing'], exit, logger });
+    expect(logger.error).toHaveBeenCalledWith('Unknown type: weird');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('runCli creates model and controller', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { modelFolder: 'app/models', controllerFolder: 'app/controllers' };\n",
+      );
+      const exit = vi.fn() as unknown as (code?: number) => never;
+      const logger = { error: vi.fn(), log: vi.fn() };
+      runCli({ argv: ['node', 'dmvc', 'generate', 'model', 'widget'], baseDir: dir, exit, logger });
+      runCli({
+        argv: ['node', 'dmvc', 'generate', 'controller', 'widget'],
+        baseDir: dir,
+        exit,
+        logger,
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.log).toHaveBeenCalled();
+      expect(existsSync(path.join(dir, 'app', 'models', 'WidgetModel.ts'))).toBe(true);
+      expect(existsSync(path.join(dir, 'app', 'controllers', 'WidgetController.ts'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('runCli reports errors from generators', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dmvc-'));
+    try {
+      writeFileSync(
+        path.join(dir, 'dmvc.config.ts'),
+        "export default { modelFolder: 'app/models' };\n",
+      );
+      const existingPath = path.join(dir, 'app', 'models', 'WidgetModel.ts');
+      mkdirSync(path.dirname(existingPath), { recursive: true });
+      writeFileSync(existingPath, 'export {};\n');
+      const exit = vi.fn() as unknown as (code?: number) => never;
+      const logger = { error: vi.fn(), log: vi.fn() };
+      runCli({ argv: ['node', 'dmvc', 'generate', 'model', 'widget'], baseDir: dir, exit, logger });
+      expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/Model already exists/));
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('runCliIfMain runs when module is main', () => {
+    const run = vi.fn();
+    runCliIfMain({ mainModule: module, requireMain: module, run });
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
 Fastify support added: BaseController.registerFastify and requireAuthFastify hooks, plus Fastify test coverage.
  - BaseController/QueryService refactor: HTTP handlers now return plain { status, data } results and accept plain query objects, making them
    framework-agnostic again.
  - Generator CLI improvements: runCli / runCliIfMain restored, stronger validation/usage errors, and much broader test coverage.
